### PR TITLE
SCRUM-347: Create owner

### DIFF
--- a/app/api/main.py
+++ b/app/api/main.py
@@ -5,6 +5,7 @@ from app.api.routes import (
     businesses,
     items,
     items_service,
+    owners,
     padel_courts,
 )
 
@@ -22,3 +23,4 @@ api_router.include_router(
     prefix="/businesses/{business_id}/padel-courts/{court_name}/available-matches",
     tags=["available-matches"],
 )
+api_router.include_router(owners.router, prefix="/owner", tags=["owner"])

--- a/app/api/routes/owners.py
+++ b/app/api/routes/owners.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, status
+
+from app.models.owner import OwnerCreate, OwnerPublic
+from app.services.owner_service import OwnerService
+from app.utilities.dependencies import SessionDep
+from app.utilities.messages import CREATE_OWNER
+
+router = APIRouter()
+
+service = OwnerService()
+
+
+@router.post(
+    "/",
+    response_model=OwnerPublic,
+    status_code=status.HTTP_201_CREATED,
+    responses={**CREATE_OWNER},  # type: ignore[dict-item]
+)
+async def create_business(*, session: SessionDep, owner_in: OwnerCreate) -> OwnerPublic:
+    """
+    Create a new Owner.
+    """
+    owner = await service.create_owner(session, owner_in)
+    return OwnerPublic.from_public(owner)

--- a/app/models/owner.py
+++ b/app/models/owner.py
@@ -1,0 +1,38 @@
+import uuid
+
+from sqlmodel import Field, SQLModel
+
+OWNER_TABLE_NAME = "owners"
+
+
+class OwnerBase(SQLModel):
+    user_public_id: uuid.UUID = Field(default_factory=uuid.uuid4, unique=True)
+    password_hash: str = Field(min_length=1, max_length=255)
+
+
+class OwnerCreate(OwnerBase):
+    pass
+
+
+class OwnerImmutable(SQLModel):
+    pass
+
+
+class OwnerUpdate(OwnerBase):
+    pass
+
+
+class Owner(OwnerBase, OwnerImmutable, table=True):
+    __tablename__ = OWNER_TABLE_NAME
+    id: int = Field(default=None, primary_key=True)
+
+
+class OwnerPublic(OwnerBase, OwnerImmutable):
+    @classmethod
+    def from_public(cls, owner: Owner) -> "OwnerPublic":
+        return cls(**owner.model_dump())
+
+
+class OwnersPublic(SQLModel):
+    data: list[OwnerPublic]
+    count: int

--- a/app/repository/owner_repository.py
+++ b/app/repository/owner_repository.py
@@ -1,0 +1,15 @@
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.owner import Owner, OwnerCreate
+
+
+class OwnerRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def create_owner(self, owner_in: OwnerCreate) -> Owner:
+        new_owner = Owner.model_validate(owner_in)
+        self.session.add(new_owner)
+        await self.session.commit()
+        await self.session.refresh(new_owner)
+        return new_owner

--- a/app/services/owner_service.py
+++ b/app/services/owner_service.py
@@ -1,0 +1,20 @@
+from sqlalchemy.exc import IntegrityError
+
+from app.models.owner import Owner, OwnerCreate
+from app.repository.owner_repository import OwnerRepository
+from app.utilities.dependencies import SessionDep
+from app.utilities.exceptions import NotUniqueException
+
+
+class OwnerService:
+    async def create_owner(self, session: SessionDep, owner: OwnerCreate) -> Owner:
+        repo = OwnerRepository(session)
+        try:
+            new_owner = await repo.create_owner(owner)
+        except IntegrityError:
+            await session.rollback()
+            raise NotUniqueException("Owner")
+        except Exception as e:
+            await session.rollback()
+            raise e
+        return new_owner

--- a/app/tests/api/routes/test_owners.py
+++ b/app/tests/api/routes/test_owners.py
@@ -1,0 +1,47 @@
+import uuid
+
+from httpx import AsyncClient
+
+from app.core.config import settings
+
+
+async def test_create_owner(
+    async_client: AsyncClient, x_api_key_header: dict[str, str]
+) -> None:
+    owner_id = str(uuid.uuid4())
+    owner_password = "<PASSWORD>"
+    owner_data = {"user_public_id": owner_id, "password_hash": owner_password}
+    response = await async_client.post(
+        f"{settings.API_V1_STR}/owner/",
+        headers=x_api_key_header,
+        json=owner_data,
+        params={"owner_id": str(owner_id)},
+    )
+    assert response.status_code == 201
+    content = response.json()
+    assert content["user_public_id"] == owner_id
+    assert content["password_hash"] == owner_password
+
+
+async def test_create_owner_already_exist_raise_error_409(
+    async_client: AsyncClient, x_api_key_header: dict[str, str]
+) -> None:
+    owner_id = str(uuid.uuid4())
+    owner_password = "<PASSWORD>"
+    owner_data = {"user_public_id": owner_id, "password_hash": owner_password}
+    response = await async_client.post(
+        f"{settings.API_V1_STR}/owner/",
+        headers=x_api_key_header,
+        json=owner_data,
+        params={"owner_id": str(owner_id)},
+    )
+    assert response.status_code == 201
+
+    response_2 = await async_client.post(
+        f"{settings.API_V1_STR}/owner/",
+        headers=x_api_key_header,
+        json=owner_data,
+        params={"owner_id": str(owner_id)},
+    )
+
+    assert response_2.status_code == 409

--- a/app/utilities/messages.py
+++ b/app/utilities/messages.py
@@ -49,3 +49,8 @@ AVAILABLE_DATE_PATCH_RESPONSES = {
     **AVAILABLE_DATE_NOT_FOUND,
     **AVAILABLE_DATE_ALREADY_RESERVED,
 }
+
+CREATE_OWNER = {
+    status.HTTP_201_CREATED: {"description": "Owner create"},
+    status.HTTP_409_CONFLICT: {"description": "Owner already created"},
+}


### PR DESCRIPTION
Generate endpoint for creation of owner

The linking of the owners table with the other tables is in [Us 349](https://tpii-padel-pals.atlassian.net/browse/SCRUM-349?atlOrigin=eyJpIjoiMWQyNWNlNWZkOGJlNDk0Yzk4OGQwYWM4NTljN2JmODIiLCJwIjoiaiJ9)


Save data in table:

- Password (HASH => str)
- Public ID (uuID)

![Dueño_login drawio](https://github.com/user-attachments/assets/4b528105-19d0-40af-9189-def35c395b0a)
